### PR TITLE
Fix connection errors

### DIFF
--- a/src/main/java/io/smilo/commons/peer/Peer.java
+++ b/src/main/java/io/smilo/commons/peer/Peer.java
@@ -42,6 +42,7 @@ public class Peer implements Runnable, IPeer {
     private Long lastPing;
     private List<Capability> capabilities = new ArrayList<>();
     private int connectionAttempts = 0;
+    private final static int PORT = 8020;
 
     /**
      * Constructor sets socket
@@ -52,7 +53,7 @@ public class Peer implements Runnable, IPeer {
         this.socket = socket;
         this.initialized = false;
         this.address = socket.getInetAddress();
-        this.remotePort = socket.getPort();
+        this.remotePort = PORT;
         this.identifier = identifier;
         setKeepAlive();
     }
@@ -60,6 +61,7 @@ public class Peer implements Runnable, IPeer {
     public Peer(String identifier, InetAddress address, int port) throws IOException {
         this(identifier, new Socket(address, port));
         this.identifier = identifier;
+        this.remotePort = port;
     }
 
     public Peer() {

--- a/src/main/java/io/smilo/commons/peer/PeerClient.java
+++ b/src/main/java/io/smilo/commons/peer/PeerClient.java
@@ -123,7 +123,6 @@ public class PeerClient {
                     IPeer peer = peerInitializer.initializePeer("", listenSocket.accept());
                     connectToPeer(peer);
                 }
-
             } catch (java.net.BindException e) {
                 LOGGER.error("Port " + listenPort + " already in use", e);
                 System.exit(-1);
@@ -140,9 +139,7 @@ public class PeerClient {
      */
     public void connectToPeer(IPeer peer) {
         try {
-            taskExecutor.execute(() -> {
-                peer.run();
-            });
+            taskExecutor.execute(() -> peer.run());
 
             // should be connected within 3 seconds, we don't want to block the flow
             int amountOfRetries = 30;
@@ -155,7 +152,6 @@ public class PeerClient {
                    return;
                }
             }
-
             if (isEmpty(peer.getIdentifier())) {
                 peer.write(PayloadType.REQUEST_IDENTIFIER.name());
                 pendingPeers.add(peer);


### PR DESCRIPTION
reconnect on port 8020 instead of the remotePort recieved by the socket.
The remote port by the socket is between 50000 - 65454, which are not opened by firewalls.

Connections should always connect using 8020!!
The tcp layer will redirect connections to localPort (binded socket port)